### PR TITLE
Reducing the number of log lines.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,18 @@ Style/Documentation:
 Metrics/LineLength:
   Max: 100
 
+Metrics/AbcSize:
+  Max: 30
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/PerceivedComplexity:
+  Max: 15
+
+Metrics/CyclomaticComplexity:
+  Max: 15
+
 Metrics/BlockLength:
   Exclude:
     - '**/spec/**/*'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    traxor (0.1.20)
+    traxor (0.2.0)
       activesupport (>= 5.0)
 
 GEM
@@ -252,6 +252,3 @@ DEPENDENCIES
   sidekiq
   simplecov
   traxor!
-
-BUNDLED WITH
-   1.17.3

--- a/lib/traxor.rb
+++ b/lib/traxor.rb
@@ -19,7 +19,7 @@ module Traxor
   end
 
   def self.enabled?
-    @enabled ||= ENV.fetch('TRAXOR_ENABLED', true).present?
+    ENV['DISABLE_TRAXOR'].blank?
   end
 
   def self.scopes
@@ -28,6 +28,8 @@ module Traxor
                 .to_s
                 .downcase
                 .split(',')
+                .map(&:strip)
+                .map(&:chomp)
                 .map(&:to_sym)
   end
 end

--- a/lib/traxor/faraday.rb
+++ b/lib/traxor/faraday.rb
@@ -12,8 +12,10 @@ module Traxor
       duration = (event.duration || 0.0).to_f
       tags = { faraday_host: url.host, faraday_method: event.payload[:method] }
 
-      Metric.count COUNT_METRIC, 1, tags
-      Metric.measure DURATION_METRIC, "#{duration.round(2)}ms", tags if duration.positive?
+      Metric::Line.record do |l|
+        l.count COUNT_METRIC, 1, tags
+        l.measure DURATION_METRIC, "#{duration.round(2)}ms", tags if duration.positive?
+      end
     end
   end
 end

--- a/lib/traxor/metric.rb
+++ b/lib/traxor/metric.rb
@@ -1,39 +1,19 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/string/inflections'
+require 'traxor/metric/line'
 
 module Traxor
   module Metric
     def self.count(name, value, tags = {})
-      log("count##{name}=#{value} #{tag_string(tags)}")
+      Line.record { |l| l.count(name, value, tags) }
     end
 
     def self.measure(name, value, tags = {})
-      log("measure##{name}=#{value} #{tag_string(tags)}")
+      Line.record { |l| l.measure(name, value, tags) }
     end
 
     def self.sample(name, value, tags = {})
-      log("sample##{name}=#{value} #{tag_string(tags)}")
-    end
-
-    def self.tag_string(tags)
-      Hash(tags).merge(Traxor::Tags.all).map do |tag_name, tag_value|
-        "tag##{tag_name}=#{tag_value}"
-      end.join(' ')
-    end
-
-    def self.normalize_values(value)
-      value.to_s.gsub(/::/, '.').underscore.strip
-    end
-
-    def self.log(string)
-      return unless Traxor.enabled?
-
-      logger.info(normalize_values(string))
-    end
-
-    def self.logger
-      Traxor.logger
+      Line.record { |l| l.sample(name, value, tags) }
     end
   end
 end

--- a/lib/traxor/metric/line.rb
+++ b/lib/traxor/metric/line.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/string/inflections'
+
+module Traxor
+  module Metric
+    class Line
+      def self.record
+        line = new
+        yield line
+        line.flush
+      end
+
+      def initialize
+        @counts = []
+        @measures = []
+        @samples = []
+        @tags = {}
+      end
+
+      def count(name, value, tags = {})
+        @counts << [name, value]
+        @tags.merge!(tags)
+      end
+
+      def measure(name, value, tags = {})
+        @measures << [name, value]
+        @tags.merge!(tags)
+      end
+
+      def sample(name, value, tags = {})
+        @samples << [name, value]
+        @tags.merge!(tags)
+      end
+
+      def flush
+        line = ''
+
+        @counts.each { |name, value| line += " count##{name}=#{value}" }
+        @measures.each { |name, value| line += " measure##{name}=#{value}" }
+        @samples.each { |name, value| line += " sample##{name}=#{value}" }
+
+        log("#{line} #{tag_string(@tags)}")
+      end
+
+      def tag_string(tags)
+        Hash(tags).merge(Traxor::Tags.all).map do |tag_name, tag_value|
+          "tag##{tag_name}=#{tag_value}"
+        end.join(' ')
+      end
+
+      def normalize_values(value)
+        value.to_s.gsub(/::/, '.').underscore.strip
+      end
+
+      def log(string)
+        return unless Traxor.enabled?
+
+        logger.info(normalize_values(string))
+      end
+
+      def logger
+        Traxor.logger
+      end
+    end
+  end
+end

--- a/lib/traxor/rails/active_record.rb
+++ b/lib/traxor/rails/active_record.rb
@@ -16,14 +16,17 @@ module Traxor
         sql = event.payload[:sql].to_s.strip.upcase
         name = event.payload[:name].to_s.strip
         return if name.casecmp('SCHEMA').zero?
+
         tags = {}
         tags[:active_record_class_name] = name.split.first if name.length.positive?
 
-        Metric.count COUNT_METRIC, 1, tags
-        Metric.count SELECT_METRIC, 1, tags if sql.start_with?('SELECT')
-        Metric.count INSERT_METRIC, 1, tags if sql.start_with?('INSERT')
-        Metric.count UPDATE_METRIC, 1, tags if sql.start_with?('UPDATE')
-        Metric.count DELETE_METRIC, 1, tags if sql.start_with?('DELETE')
+        Metric::Line.record do |l|
+          l.count COUNT_METRIC, 1, tags
+          l.count SELECT_METRIC, 1, tags if sql.start_with?('SELECT')
+          l.count INSERT_METRIC, 1, tags if sql.start_with?('INSERT')
+          l.count UPDATE_METRIC, 1, tags if sql.start_with?('UPDATE')
+          l.count DELETE_METRIC, 1, tags if sql.start_with?('DELETE')
+        end
       end
 
       def self.record_instantiations(event)

--- a/lib/traxor/sidekiq/middleware.rb
+++ b/lib/traxor/sidekiq/middleware.rb
@@ -10,9 +10,11 @@ module Traxor
 
       def call(worker, _job, queue)
         tags = Traxor::Tags.sidekiq = { sidekiq_worker: worker.class.name, sidekiq_queue: queue }
-        Metric.count COUNT_METRIC, 1, tags
-        time = Benchmark.ms { yield }
-        Metric.measure DURATION_METRIC, "#{time.round(2)}ms", tags if time.positive?
+        Metric::Line.record do |l|
+          l.count COUNT_METRIC, 1, tags
+          time = Benchmark.ms { yield }
+          l.measure DURATION_METRIC, "#{time.round(2)}ms", tags if time.positive?
+        end
       end
     end
   end

--- a/lib/traxor/version.rb
+++ b/lib/traxor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Traxor
-  VERSION = '0.1.20'
+  VERSION = '0.2.0'
 end

--- a/spec/traxor/faraday_spec.rb
+++ b/spec/traxor/faraday_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe Traxor::Faraday do
     let(:tags) { { faraday_host: 'www.google.com', faraday_method: :GET } }
 
     it 'records the metrics' do
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Faraday::COUNT_METRIC, 1, tags)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Faraday::DURATION_METRIC, '50.0ms', tags)
       )
 

--- a/spec/traxor/metric/line_spec.rb
+++ b/spec/traxor/metric/line_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe Traxor::Metric::Line do
+  let(:instance) { described_class.new }
+
+  describe '#count' do
+    subject(:record_metric) { instance.count('requests', '4') }
+
+    let(:expected_metric_string) { ' count#requests=4 ' }
+
+    it 'logs the metric' do
+      expect(instance).to receive(:log).with(expected_metric_string)
+
+      record_metric
+      instance.flush
+    end
+  end
+
+  describe '#measure' do
+    subject(:record_metric) { instance.measure('duration', '10ms', a: 1) }
+
+    let(:expected_metric_string) { ' measure#duration=10ms tag#a=1' }
+
+    it 'logs the metric' do
+      expect(instance).to receive(:log).with(expected_metric_string)
+
+      record_metric
+      instance.flush
+    end
+  end
+
+  describe '#sample' do
+    subject(:record_metric) { instance.sample('memory', '100', b: 2, c: 3) }
+
+    let(:expected_metric_string) { ' sample#memory=100 tag#b=2 tag#c=3' }
+
+    it 'logs the metric' do
+      expect(instance).to receive(:log).with(expected_metric_string)
+
+      record_metric
+      instance.flush
+    end
+  end
+
+  describe '#tag_string' do
+    subject(:tag_string) { instance.tag_string(tags) }
+
+    let(:tags) { { d: 4, e: 5 } }
+
+    it 'only includes the immediate tags' do
+      Thread.new do
+        Traxor::Tags.controller = nil
+        Traxor::Tags.sidekiq = nil
+
+        expect(tag_string).to eq('tag#d=4 tag#e=5')
+      end.join
+    end
+
+    it 'uses the global values when present' do
+      Thread.new do
+        Traxor::Tags.controller = { controller: 1 }
+        Traxor::Tags.sidekiq = { sidekiq: 2 }
+
+        expect(tag_string).to include('tag#controller=1')
+        expect(tag_string).to include('tag#sidekiq=2')
+      end.join
+    end
+  end
+
+  describe '#normalize_values' do
+    module ParentModule
+      module ChildModule; end
+    end
+
+    subject { instance.normalize_values(value) }
+
+    let(:value) { ParentModule::ChildModule }
+    let(:normalized) { 'parent_module.child_module' }
+
+    it { is_expected.to eq(normalized) }
+  end
+
+  describe '#log' do
+    let(:unformatted) { 'THE::TestThis.a_b' }
+    let(:formatted) { 'the.test_this.a_b' }
+
+    it 'logs an info string normalized' do
+      expect(instance.logger).to receive(:info).with(formatted)
+
+      instance.log(unformatted)
+    end
+  end
+end

--- a/spec/traxor/metric_spec.rb
+++ b/spec/traxor/metric_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Traxor::Metric do
   describe '.count' do
     subject(:record_metric) { described_class.count('requests', '4') }
 
-    let(:expected_metric_string) { 'count#requests=4 ' }
+    let(:expected_metric_string) { ' count#requests=4 ' }
 
     it 'logs the metric' do
-      expect(described_class).to receive(:log).with(expected_metric_string)
+      expect_any_instance_of(Traxor::Metric::Line).to receive(:log).with(expected_metric_string)
 
       record_metric
     end
@@ -16,10 +16,10 @@ RSpec.describe Traxor::Metric do
   describe '.measure' do
     subject(:record_metric) { described_class.measure('duration', '10ms', a: 1) }
 
-    let(:expected_metric_string) { 'measure#duration=10ms tag#a=1' }
+    let(:expected_metric_string) { ' measure#duration=10ms tag#a=1' }
 
     it 'logs the metric' do
-      expect(described_class).to receive(:log).with(expected_metric_string)
+      expect_any_instance_of(Traxor::Metric::Line).to receive(:log).with(expected_metric_string)
 
       record_metric
     end
@@ -28,61 +28,12 @@ RSpec.describe Traxor::Metric do
   describe '.sample' do
     subject(:record_metric) { described_class.sample('memory', '100', b: 2, c: 3) }
 
-    let(:expected_metric_string) { 'sample#memory=100 tag#b=2 tag#c=3' }
+    let(:expected_metric_string) { ' sample#memory=100 tag#b=2 tag#c=3' }
 
     it 'logs the metric' do
-      expect(described_class).to receive(:log).with(expected_metric_string)
+      expect_any_instance_of(Traxor::Metric::Line).to receive(:log).with(expected_metric_string)
 
       record_metric
-    end
-  end
-
-  describe '.tag_string' do
-    subject(:tag_string) { described_class.tag_string(tags) }
-
-    let(:tags) { { d: 4, e: 5 } }
-
-    it 'only includes the immediate tags' do
-      Thread.new do
-        Traxor::Tags.controller = nil
-        Traxor::Tags.sidekiq = nil
-
-        expect(tag_string).to eq('tag#d=4 tag#e=5')
-      end.join
-    end
-
-    it 'uses the global values when present' do
-      Thread.new do
-        Traxor::Tags.controller = { controller: 1 }
-        Traxor::Tags.sidekiq = { sidekiq: 2 }
-
-        expect(tag_string).to include('tag#controller=1')
-        expect(tag_string).to include('tag#sidekiq=2')
-      end.join
-    end
-  end
-
-  describe '.normalize_values' do
-    module ParentModule
-      module ChildModule; end
-    end
-
-    subject { described_class.normalize_values(value) }
-
-    let(:value) { ParentModule::ChildModule }
-    let(:normalized) { 'parent_module.child_module' }
-
-    it { is_expected.to eq(normalized) }
-  end
-
-  describe '.log' do
-    let(:unformatted) { 'THE::TestThis.a_b' }
-    let(:formatted) { 'the.test_this.a_b' }
-
-    it 'logs an info string normalized' do
-      expect(described_class.logger).to receive(:info).with(formatted)
-
-      described_class.log(unformatted)
     end
   end
 end

--- a/spec/traxor/rack/middleware/pre_spec.rb
+++ b/spec/traxor/rack/middleware/pre_spec.rb
@@ -52,7 +52,11 @@ RSpec.describe Traxor::Rack::Middleware::Pre do
 
   it 'records the gc duration' do
     Thread.new do
-      expect(Traxor::Metric).to(
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:measure)
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:count)
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:sample)
+
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(
           Traxor::Rack::Middleware::Pre::GC_DURATION_METRIC,
           "#{(fake_gc_duration * 1_000).to_f.round(2)}ms"
@@ -65,16 +69,20 @@ RSpec.describe Traxor::Rack::Middleware::Pre do
 
   it 'records the request metrics' do
     Thread.new do
-      expect(Traxor::Metric).to(
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:measure)
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:count)
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:sample)
+
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Rack::Middleware::Pre::MIDDLEWARE_METRIC, any_args)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Rack::Middleware::Pre::DURATION_METRIC, any_args)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Rack::Middleware::Pre::QUEUE_METRIC, any_args)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Rack::Middleware::Pre::REQUEST_COUNT_METRIC, any_args)
       )
 
@@ -87,19 +95,23 @@ RSpec.describe Traxor::Rack::Middleware::Pre do
 
   it 'records the gc metrics' do
     Thread.new do
-      expect(Traxor::Metric).to(
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:measure)
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:count)
+      allow_any_instance_of(Traxor::Metric::Line).to receive(:sample)
+
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Rack::Middleware::Pre::GC_DURATION_METRIC, any_args)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Rack::Middleware::Pre::GC_COUNT_METRIC, any_args)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Rack::Middleware::Pre::MAJOR_METRIC, any_args)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Rack::Middleware::Pre::MINOR_METRIC, any_args)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Rack::Middleware::Pre::ALLOCATED_METRIC, any_args)
       )
 

--- a/spec/traxor/rails/action_controller_spec.rb
+++ b/spec/traxor/rails/action_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'traxor/rails/action_controller'
 
 RSpec.describe Traxor::Rails::ActionController do
-  describe '.set_controller_tags' do
+  describe '.add_controller_tags' do
     let(:event) do
       ActiveSupport::Notifications::Event.new(
         nil,
@@ -25,7 +25,7 @@ RSpec.describe Traxor::Rails::ActionController do
 
     it 'sets global controller tags' do
       Thread.new do
-        described_class.set_controller_tags(event)
+        described_class.add_controller_tags(event)
 
         expect(Traxor::Tags.controller).to eq(tags)
       end.join
@@ -48,22 +48,22 @@ RSpec.describe Traxor::Rails::ActionController do
     let(:tags) { { faraday_host: 'www.google.com', faraday_method: :GET } }
 
     it 'records the metrics' do
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Rails::ActionController::COUNT_METRIC, 1)
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Rails::ActionController::TOTAL_METRIC, '1000.0ms')
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Rails::ActionController::RUBY_METRIC, '945.0ms')
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Rails::ActionController::DB_METRIC, '30.0ms')
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:measure).with(Traxor::Rails::ActionController::VIEW_METRIC, '25.0ms')
       )
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Rails::ActionController::EXCEPTION_METRIC, 1)
       )
 
@@ -72,8 +72,8 @@ RSpec.describe Traxor::Rails::ActionController do
   end
 
   describe 'subscriptions' do
-    it 'calls set_controller_tags' do
-      expect(described_class).to receive(:set_controller_tags)
+    it 'calls add_controller_tags' do
+      expect(described_class).to receive(:add_controller_tags)
 
       ActiveSupport::Notifications.instrument('start_processing.action_controller')
     end

--- a/spec/traxor/rails/active_record_spec.rb
+++ b/spec/traxor/rails/active_record_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Traxor::Rails::ActiveRecord do
     let(:tags) { { active_record_class_name: 'MyModel' } }
 
     it 'records the metrics' do
-      expect(Traxor::Metric).to(
+      expect_any_instance_of(Traxor::Metric::Line).to(
         receive(:count).with(Traxor::Rails::ActiveRecord::COUNT_METRIC, 1, tags)
       )
 
@@ -29,10 +29,10 @@ RSpec.describe Traxor::Rails::ActiveRecord do
       before { event.payload[:sql] = 'select' }
 
       it 'records the metrics' do
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::COUNT_METRIC, 1, tags)
         )
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::SELECT_METRIC, 1, tags)
         )
 
@@ -44,10 +44,10 @@ RSpec.describe Traxor::Rails::ActiveRecord do
       before { event.payload[:sql] = 'insert' }
 
       it 'records the metrics' do
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::COUNT_METRIC, 1, tags)
         )
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::INSERT_METRIC, 1, tags)
         )
 
@@ -59,10 +59,10 @@ RSpec.describe Traxor::Rails::ActiveRecord do
       before { event.payload[:sql] = 'update' }
 
       it 'records the metrics' do
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::COUNT_METRIC, 1, tags)
         )
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::UPDATE_METRIC, 1, tags)
         )
 
@@ -74,10 +74,10 @@ RSpec.describe Traxor::Rails::ActiveRecord do
       before { event.payload[:sql] = 'delete' }
 
       it 'records the metrics' do
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::COUNT_METRIC, 1, tags)
         )
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::DELETE_METRIC, 1, tags)
         )
 
@@ -86,13 +86,13 @@ RSpec.describe Traxor::Rails::ActiveRecord do
     end
 
     context 'when invalid event' do
-      before { event.payload[:name] = 'sCheMa' }
+      before { event.payload[:name] = 'schema' }
 
       it 'does not record the metrics' do
-        expect(Traxor::Metric).not_to(
+        expect_any_instance_of(Traxor::Metric::Line).not_to(
           receive(:count).with(Traxor::Rails::ActiveRecord::COUNT_METRIC, any_args)
         )
-        expect(Traxor::Metric).not_to(
+        expect_any_instance_of(Traxor::Metric::Line).not_to(
           receive(:count).with(Traxor::Rails::ActiveRecord::COUNT_METRIC, any_args)
         )
 
@@ -104,7 +104,7 @@ RSpec.describe Traxor::Rails::ActiveRecord do
       before { event.payload[:name] = '' }
 
       it 'does not record the tags' do
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Rails::ActiveRecord::COUNT_METRIC, 1, {})
         )
 

--- a/spec/traxor/sidekiq/middleware_spec.rb
+++ b/spec/traxor/sidekiq/middleware_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Traxor::Sidekiq::Middleware do
 
     it 'records metrics' do
       Thread.new do
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:measure).with(Traxor::Sidekiq::Middleware::DURATION_METRIC, any_args, tags)
         )
-        expect(Traxor::Metric).to(
+        expect_any_instance_of(Traxor::Metric::Line).to(
           receive(:count).with(Traxor::Sidekiq::Middleware::COUNT_METRIC, 1, tags)
         )
 


### PR DESCRIPTION
By default Traxor was putting each new entry on a separate line.

It will naw try to group what it can on a single line of metrics.

Also fixing a bug where the env var to disable traxor did nothing.